### PR TITLE
PHOENIX-6303 bump Scala version for spark connector to 2.11.12, the s…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <flume.version>1.4.0</flume.version>
     <kafka.version>0.9.0.0</kafka.version>
     <spark.version>2.4.0</spark.version>
-    <scala.version>2.11.8</scala.version>
+    <scala.version>2.11.12</scala.version>
     <scala.binary.version>2.11</scala.binary.version>
     
     <log4j.version>1.2.17</log4j.version>


### PR DESCRIPTION
…ame that Spark 2.4.7 uses