### PR TITLE
PHOENIX-6698 hive-connector will take long time to generate splits fo…

### DIFF
--- a/phoenix-hive-base/src/main/java/org/apache/phoenix/hive/mapreduce/PhoenixInputFormat.java
+++ b/phoenix-hive-base/src/main/java/org/apache/phoenix/hive/mapreduce/PhoenixInputFormat.java
@@ -24,6 +24,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.*;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.HConstants;
@@ -128,66 +130,102 @@ public class PhoenixInputFormat<T extends DBWritable> implements InputFormat<Wri
         }
         final List<InputSplit> psplits = new ArrayList<>(splits.size());
 
-        Path[] tablePaths = FileInputFormat.getInputPaths(ShimLoader.getHadoopShims()
+        final Path[] tablePaths = FileInputFormat.getInputPaths(ShimLoader.getHadoopShims()
                 .newJobContext(new Job(jobConf)));
-        boolean splitByStats = jobConf.getBoolean(PhoenixStorageHandlerConstants.SPLIT_BY_STATS,
+        final boolean splitByStats = jobConf.getBoolean(PhoenixStorageHandlerConstants.SPLIT_BY_STATS,
                 false);
-
+        final int parallelThreshould = jobConf.getInt("hive.phoenix.split.parallel.threshold", 32);
         setScanCacheSize(jobConf);
+        if ( (parallelThreshould) <=0 || (qplan.getScans().size() < parallelThreshould) ){
+            LOG.info("generate splits in serial");
+            for (final List<Scan> scans : qplan.getScans()) {
+                psplits.addAll(generateSplitsInternal(jobConf,qplan, splits, query,scans,splitByStats,tablePaths));
+            }
+        } else {
+            final int parallism = jobConf.getInt("hive.phoenix.split.parallel.level",Runtime.getRuntime().availableProcessors()*2);
+            ExecutorService executorService = Executors.newFixedThreadPool(parallism);
+            LOG.info("generate splits in parallel with {} threads",parallism);
 
-        // Adding Localization
-        try (org.apache.hadoop.hbase.client.Connection connection = ConnectionFactory.createConnection(PhoenixConnectionUtil.getConfiguration(jobConf))) {
-        RegionLocator regionLocator = connection.getRegionLocator(TableName.valueOf(qplan
-                .getTableRef().getTable().getPhysicalName().toString()));
+            List<Future<List<InputSplit>>> tasks = new ArrayList<>();
 
-        for (List<Scan> scans : qplan.getScans()) {
-            PhoenixInputSplit inputSplit;
+            try{
+                for (final List<Scan> scans : qplan.getScans()) {
+                    Future<List<InputSplit>> task= executorService.submit(new Callable<List<InputSplit>>() {
+                        @Override
+                        public List<InputSplit> call() throws Exception {
+                            return generateSplitsInternal(jobConf,qplan, splits, query,scans,splitByStats,tablePaths);
+                        }
+                    });
+                    tasks.add(task);
+                }
+                for (Future<List<InputSplit>> task : tasks) {
+                    psplits.addAll(task.get());
+                }
+            }catch (ExecutionException | InterruptedException exception){
+                throw new RuntimeException("failed to get splits,reason:",exception);
+            }finally {
+                executorService.shutdown();
+            }
+        }
+        return psplits;
+    }
 
-            HRegionLocation location = regionLocator.getRegionLocation(scans.get(0).getStartRow()
-                    , false);
-            long regionSize = CompatUtil.getSize(regionLocator, connection.getAdmin(), location);
-            String regionLocation = PhoenixStorageHandlerUtil.getRegionLocation(location, LOG);
+    private List<InputSplit> generateSplitsInternal(final JobConf jobConf, final QueryPlan qplan,
+            final List<KeyRange> splits, final String query,final List<Scan> scans,final boolean splitByStats,final Path[] tablePaths) throws
+            IOException {
 
-            if (splitByStats) {
-                for (Scan aScan : scans) {
+        final List<InputSplit> psplits = new ArrayList<>(scans.size());
+        try (org.apache.hadoop.hbase.client.Connection connection = ConnectionFactory.createConnection(
+                PhoenixConnectionUtil.getConfiguration(jobConf))) {
+            RegionLocator
+                    regionLocator =
+                    connection.getRegionLocator(TableName.valueOf(
+                            qplan.getTableRef().getTable().getPhysicalName().toString()));
+
+            {
+                PhoenixInputSplit inputSplit;
+
+                HRegionLocation location = regionLocator.getRegionLocation(scans.get(0).getStartRow(), false);
+                long regionSize = CompatUtil.getSize(regionLocator, connection.getAdmin(), location);
+                String regionLocation = PhoenixStorageHandlerUtil.getRegionLocation(location, LOG);
+
+                if (splitByStats) {
+                    for (Scan aScan : scans) {
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug("Split for  scan : " + aScan + "with scanAttribute : " + aScan.getAttributesMap()
+                                    + " [scanCache, cacheBlock, scanBatch] : [" + aScan.getCaching()
+                                    + ", " + aScan.getCacheBlocks() + ", " + aScan.getBatch() + "] and  regionLocation : " + regionLocation);
+                        }
+
+                        inputSplit =
+                                new PhoenixInputSplit(new ArrayList<>(Arrays.asList(aScan)),
+                                        tablePaths[0], regionLocation, regionSize);
+                        inputSplit.setQuery(query);
+                        psplits.add(inputSplit);
+                    }
+                } else {
                     if (LOG.isDebugEnabled()) {
-                        LOG.debug("Split for  scan : " + aScan + "with scanAttribute : " + aScan
-                                .getAttributesMap() + " [scanCache, cacheBlock, scanBatch] : [" +
-                                aScan.getCaching() + ", " + aScan.getCacheBlocks() + ", " + aScan
-                                .getBatch() + "] and  regionLocation : " + regionLocation);
+                        LOG.debug("Scan count[" + scans.size() + "] : " + Bytes.toStringBinary(
+                                scans.get(0).getStartRow()) + " ~ " + Bytes.toStringBinary(
+                                scans.get(scans.size() - 1).getStopRow()));
+                        LOG.debug("First scan : " + scans.get(0) + "with scanAttribute : " + scans.get(0).getAttributesMap()
+                                + " [scanCache, cacheBlock, scanBatch] : " + "[" + scans.get(0).getCaching() + ", " + scans.get(0).getCacheBlocks()
+                                + ", " + scans.get(0).getBatch() + "] and  regionLocation : "
+                                + regionLocation);
+
+                        for (int i = 0, limit = scans.size(); i < limit; i++) {
+                            LOG.debug("EXPECTED_UPPER_REGION_KEY[" + i + "] : " + Bytes.toStringBinary(scans.get(i).getAttribute(
+                                    BaseScannerRegionObserver.EXPECTED_UPPER_REGION_KEY)));
+                        }
                     }
 
-                    inputSplit = new PhoenixInputSplit(new ArrayList<>(Arrays.asList(aScan)), tablePaths[0],
-                            regionLocation, regionSize);
+                    inputSplit =
+                            new PhoenixInputSplit(scans, tablePaths[0], regionLocation, regionSize);
                     inputSplit.setQuery(query);
                     psplits.add(inputSplit);
                 }
-            } else {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Scan count[" + scans.size() + "] : " + Bytes.toStringBinary(scans
-                            .get(0).getStartRow()) + " ~ " + Bytes.toStringBinary(scans.get(scans
-                            .size() - 1).getStopRow()));
-                    LOG.debug("First scan : " + scans.get(0) + "with scanAttribute : " + scans
-                            .get(0).getAttributesMap() + " [scanCache, cacheBlock, scanBatch] : " +
-                            "[" + scans.get(0).getCaching() + ", " + scans.get(0).getCacheBlocks()
-                            + ", " + scans.get(0).getBatch() + "] and  regionLocation : " +
-                            regionLocation);
-
-                    for (int i = 0, limit = scans.size(); i < limit; i++) {
-                        LOG.debug("EXPECTED_UPPER_REGION_KEY[" + i + "] : " + Bytes
-                                .toStringBinary(scans.get(i).getAttribute
-                                        (BaseScannerRegionObserver.EXPECTED_UPPER_REGION_KEY)));
-                    }
-                }
-
-                inputSplit = new PhoenixInputSplit(scans, tablePaths[0], regionLocation,
-                        regionSize);
-                inputSplit.setQuery(query);
-                psplits.add(inputSplit);
             }
         }
-		}
-
         return psplits;
     }
 

--- a/phoenix-hive-base/src/test/java/org/apache/phoenix/hive/HivePhoenixInputFormatTest.java
+++ b/phoenix-hive-base/src/test/java/org/apache/phoenix/hive/HivePhoenixInputFormatTest.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.phoenix.hive;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.mapred.InputSplit;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.phoenix.end2end.ParallelStatsDisabledIT;
+import org.apache.phoenix.end2end.ParallelStatsDisabledTest;
+import org.apache.phoenix.hive.constants.PhoenixStorageHandlerConstants;
+import org.apache.phoenix.hive.mapreduce.PhoenixInputFormat;
+import org.apache.phoenix.mapreduce.PhoenixRecordWritable;
+import org.apache.phoenix.schema.TableAlreadyExistsException;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.concurrent.NotThreadSafe;
+import java.io.IOException;
+import java.sql.*;
+import java.util.Locale;
+import java.util.Properties;
+
+/**
+ * Test class for Hive PhoenixInputFormat
+ */
+@NotThreadSafe
+@Category(ParallelStatsDisabledTest.class)
+public class HivePhoenixInputFormatTest extends ParallelStatsDisabledIT {
+    private static final Logger LOG = LoggerFactory.getLogger(HivePhoenixInputFormatTest.class);
+    private static final String TABLE_NAME = "HivePhoenixInputFormatTest".toUpperCase(Locale.ROOT);
+    private static final String DDL = "CREATE TABLE " + TABLE_NAME + " (V1 varchar NOT NULL PRIMARY KEY, V2 integer)";
+    private static final int SPLITS = 128;
+
+    @Test
+    public void testGetSplitsSerialOrParallel() throws IOException,SQLException {
+        PhoenixInputFormat<PhoenixRecordWritable> inputFormat = new PhoenixInputFormat<PhoenixRecordWritable>();
+        long start,end;
+
+        // create table with N splits
+        System.out.println(String.format("generate testing table with %s splits",String.valueOf(SPLITS)));
+        setupTestTable();
+        // setup configuration required for PhoenixInputFormat
+        Configuration conf = getUtility().getConfiguration();
+        JobConf jobConf = new JobConf(conf);
+        configureTestInput(jobConf);
+
+
+        // test get splits in serial
+        start = System.currentTimeMillis();
+        jobConf.set("hive.phoenix.split.parallel.threshold","0");
+        InputSplit[] inputSplitsSerial = inputFormat.getSplits(jobConf,SPLITS);
+        end = System.currentTimeMillis();
+        long durationInSerial=end - start;
+        System.out.println(String.format("get split in serial requires:%s ms",String.valueOf(durationInSerial)));
+
+        // test get splits in parallel
+        start = System.currentTimeMillis();
+        jobConf.set("hive.phoenix.split.parallel.threshold","1");
+        InputSplit[] inputSplitsParallel = inputFormat.getSplits(jobConf,SPLITS);
+        end = System.currentTimeMillis();
+        long durationInParallel=end - start;
+
+        System.out.println(String.format("get split in parallel requires:%s ms",String.valueOf(durationInParallel)));
+
+        // Test if performance of parallel method is better than serial method
+        Assert.assertTrue(durationInParallel < durationInSerial);
+        // Test if the input split returned by serial method and parallel method are the same
+        Assert.assertTrue(inputSplitsParallel.length==SPLITS);
+        Assert.assertTrue(inputSplitsParallel.length == inputSplitsSerial.length);
+        for (final InputSplit inputSplitParallel:inputSplitsParallel){
+            boolean match=false;
+            for (final InputSplit inputSplitSerial:inputSplitsSerial){
+                if (inputSplitParallel.equals(inputSplitSerial)){
+                    match=true;
+                    break;
+                }
+            }
+            Assert.assertTrue(match);
+        }
+    }
+
+    private static void setupTestTable() throws SQLException {
+        final byte [] start=new byte[0];
+        final byte [] end = Bytes.createMaxByteArray(4);
+        final byte[][] splits = Bytes.split(start, end, SPLITS-2);
+        createTestTableWithBinarySplit(getUrl(),DDL, splits ,null);
+    }
+
+    private static void buildPreparedSqlWithBinarySplits(StringBuffer sb,int splits)
+    {
+        int splitPoints = splits -1;
+        sb.append(" SPLIT ON(");
+        sb.append("?");
+        for (int i = 1; i < splitPoints; i++) {
+            sb.append(",?");
+        }
+        sb.append(")");
+    }
+
+    private static PreparedStatement createPreparedStatement(Connection connection, String newSql,byte [][] splitsBytes) throws SQLException {
+        final PreparedStatement statement = (PreparedStatement) connection.prepareStatement(newSql);
+        final int splitPoints = splitsBytes.length-1;
+        for (int i = 1; i <= splitPoints; i++) {
+            statement.setBytes(i, splitsBytes[i]);
+        }
+        return statement;
+    }
+
+    protected static void createTestTableWithBinarySplit(String url, String ddl, byte[][] splits, Long ts) throws SQLException {
+        Assert.assertNotNull(ddl);
+        StringBuffer buf = new StringBuffer(ddl);
+        buildPreparedSqlWithBinarySplits(buf, splits.length);
+
+        ddl = buf.toString();
+        Properties props = new Properties();
+        if (ts != null) {
+            props.setProperty("CurrentSCN", Long.toString(ts));
+        }
+
+        Connection conn = DriverManager.getConnection(url, props);
+
+        try {
+            try(Statement stmt = conn.createStatement()) {
+                stmt.execute("DROP TABLE IF EXISTS " + TABLE_NAME);
+            }
+            try(PreparedStatement statement = createPreparedStatement(conn,ddl.toString(),splits)){
+                statement.execute();
+            }
+            try(Statement stmt = conn.createStatement()) {
+                stmt.execute("UPSERT INTO " + TABLE_NAME +" VALUES('1',1)");
+            }
+        } catch (TableAlreadyExistsException var12) {
+                throw var12;
+        } finally {
+            conn.close();
+        }
+
+    }
+
+    protected static void configureTestInput(JobConf jobConf){
+        jobConf.set(PhoenixStorageHandlerConstants.PHOENIX_TABLE_NAME,TABLE_NAME);
+        jobConf.set("ColumnProjectionUtils.READ_COLUMN_NAMES_CONF_STR","");
+        jobConf.set("PhoenixStorageHandlerConstants.PHOENIX_COLUMN_MAPPING","v1:V1,v2:V2");
+        jobConf.set("phoenix.zookeeper.quorum","localhost");
+        jobConf.set("phoenix.zookeeper.client.port",String.valueOf(getZKClientPort(jobConf)));
+        jobConf.set("mapreduce.input.fileinputformat.inputdir","/tmp");
+    }
+}


### PR DESCRIPTION
This patch enables PhoenixInputFormat to generate splits in parallel, it introduce two parameters to control the degree of parallelism.
1.'hive.phoenix.split.parallel.threshold' is used to contrl if split should be generated in parallel.it will generate splits in serial for following condition:
(1) hive.phoenix.split.parallel.threshold<0, it will generate split in serial.
(2) number of scans in query plan is less than the value setting.
in other conditions, it will generate split in parallel.
2. hive.phoenix.split.parallel.level
is used to control the number of work threads for the splits.(2*cpu cores by default).
A unit test is created for unit test,  the test case will compare the time cost of generating split for phoenix table with 128 regions.
the output shows that: parallel method is 6x faster than serial method, and it will be better for tables with more regions
```
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/home/jichen/.m2/repository/org/apache/logging/log4j/log4j-slf4j-impl/2.10.0/log4j-slf4j-impl-2.10.0.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/home/jichen/.m2/repository/org/slf4j/slf4j-log4j12/1.7.30/slf4j-log4j12-1.7.30.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.apache.logging.slf4j.Log4jLoggerFactory]
Formatting using clusterid: testClusterID
generate testing table with 128 splits
get split in serial requires:12843 ms
get split in parallel requires:2728 ms
```
in production environment, we have tested the time cost for table with 2048 regions, it reduces time cost from nearly 30 mins to 2 mins with default configuration.