### PR TITLE
Revert "Bump protobuf-java from 2.5.0 to 3.16.1 in /phoenix5-spark3 (…

### DIFF
--- a/phoenix5-spark3/pom.xml
+++ b/phoenix5-spark3/pom.xml
@@ -122,7 +122,7 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>3.16.1</version>
+      <version>2.5.0</version>
       <scope>provided</scope>
     </dependency>
 


### PR DESCRIPTION
…#81)"

This reverts commit aa02b3463a07dea29c60d4f3be43f2fb2ce9a0e2.