### PR TITLE
PHOENIX-6667 Support save to Phoenix without specifying all the columns in Spark3 connector

### DIFF
--- a/phoenix5-spark3-it/src/it/scala/org/apache/phoenix/spark/PhoenixSparkIT.scala
+++ b/phoenix5-spark3-it/src/it/scala/org/apache/phoenix/spark/PhoenixSparkIT.scala
@@ -616,8 +616,7 @@ class PhoenixSparkIT extends AbstractPhoenixSparkIT {
     count shouldEqual 1L
   }
 
-  //Spark3 doesn't seem to be able to handle case sensitive column names
-  ignore("Ensure DataFrame field normalization (PHOENIX-2196)") {
+  test("Ensure DataFrame field normalization (PHOENIX-2196)") {
     val rdd1 = spark.sparkContext
       .parallelize(Seq((1L, 1L, "One"), (2L, 2L, "Two")))
       .map(p => Row(p._1, p._2, p._3))

--- a/phoenix5-spark3-it/src/it/scala/org/apache/phoenix/spark/PhoenixSparkIT.scala
+++ b/phoenix5-spark3-it/src/it/scala/org/apache/phoenix/spark/PhoenixSparkIT.scala
@@ -363,10 +363,10 @@ class PhoenixSparkIT extends AbstractPhoenixSparkIT {
     stringValue shouldEqual "test_row_1"
   }
 
-  // This works with Spark2, but Spark3 enforces specifying every column
-  ignore("Can save to phoenix table from Spark2") {
+  test("Can save to phoenix table from Spark without specifying all the columns") {
     val dataSet = List(Row(1L, "1", 1), Row(2L, "2", 2), Row(3L, "3", 3))
 
+    // COL3 is missing both from the schema and from the dataset
     val schema = StructType(
       Seq(StructField("ID", LongType, nullable = false),
         StructField("COL1", StringType),
@@ -385,10 +385,10 @@ class PhoenixSparkIT extends AbstractPhoenixSparkIT {
 
     // Load the results back
     val stmt = conn.createStatement()
-    val rs = stmt.executeQuery("SELECT ID, COL1, COL2 FROM OUTPUT_TEST_TABLE")
+    val rs = stmt.executeQuery("SELECT ID, COL1, COL2, COL3 FROM OUTPUT_TEST_TABLE")
     val results = ListBuffer[Row]()
     while (rs.next()) {
-      results.append(Row(rs.getLong(1), rs.getString(2), rs.getInt(3)))
+      results.append(Row(rs.getLong(1), rs.getString(2), rs.getInt(3), rs.getDate(4)))
     }
   }
 

--- a/phoenix5-spark3/src/main/java/org/apache/phoenix/spark/sql/connector/PhoenixTable.java
+++ b/phoenix5-spark3/src/main/java/org/apache/phoenix/spark/sql/connector/PhoenixTable.java
@@ -38,7 +38,8 @@ public class PhoenixTable implements SupportsRead, SupportsWrite{
     private final Map<String,String> options;
     private final String tableName;
     private final StructType schema;
-    private static final Set<TableCapability> capabilities = ImmutableSet.of(TableCapability.BATCH_READ, TableCapability.BATCH_WRITE);
+    private static final Set<TableCapability> capabilities =
+      ImmutableSet.of(TableCapability.BATCH_READ, TableCapability.BATCH_WRITE, TableCapability.ACCEPT_ANY_SCHEMA);
 
     public PhoenixTable(StructType schema, Map<String,String> options) {
         this.options = options;

--- a/phoenix5-spark3/src/main/java/org/apache/phoenix/spark/sql/connector/PhoenixTable.java
+++ b/phoenix5-spark3/src/main/java/org/apache/phoenix/spark/sql/connector/PhoenixTable.java
@@ -23,6 +23,9 @@ import org.apache.phoenix.spark.sql.connector.writer.PhoenixWriteBuilder;
 import org.apache.spark.sql.connector.catalog.SupportsRead;
 import org.apache.spark.sql.connector.catalog.SupportsWrite;
 import org.apache.spark.sql.connector.catalog.TableCapability;
+import org.apache.spark.sql.connector.catalog.TableCapability.ACCEPT_ANY_SCHEMA;
+import org.apache.spark.sql.connector.catalog.TableCapability.BATCH_READ;
+import org.apache.spark.sql.connector.catalog.TableCapability.BATCH_WRITE;
 import org.apache.spark.sql.connector.read.ScanBuilder;
 import org.apache.spark.sql.connector.write.LogicalWriteInfo;
 import org.apache.spark.sql.connector.write.WriteBuilder;
@@ -38,8 +41,8 @@ public class PhoenixTable implements SupportsRead, SupportsWrite{
     private final Map<String,String> options;
     private final String tableName;
     private final StructType schema;
-    private static final Set<TableCapability> capabilities =
-      ImmutableSet.of(TableCapability.BATCH_READ, TableCapability.BATCH_WRITE, TableCapability.ACCEPT_ANY_SCHEMA);
+    private static final Set<TableCapability> CAPABILITIES =
+      ImmutableSet.of(BATCH_READ, BATCH_WRITE, ACCEPT_ANY_SCHEMA);
 
     public PhoenixTable(StructType schema, Map<String,String> options) {
         this.options = options;
@@ -64,7 +67,7 @@ public class PhoenixTable implements SupportsRead, SupportsWrite{
 
     @Override
     public Set<TableCapability> capabilities() {
-        return capabilities;
+        return CAPABILITIES;
     }
 
     public Map<String, String> getOptions() {


### PR DESCRIPTION
With the `ACCEPT_ANY_SCHEMA` TableCapability columns can be omitted.

Tested:
```
$ mvn clean install -rf phoenix5-spark3  -Dscala-tests-enabled
$ grep "Can save to phoenix table from Spark without specifying all the columns\|PHOENIX-2196\|succ" ./phoenix5-spark3-it/target/surefire-reports/TestSuite.txt
- Can save to phoenix table from Spark without specifying all the columns (103 milliseconds)
- Ensure DataFrame field normalization (PHOENIX-2196) (98 milliseconds)
Tests: succeeded 44, failed 0, canceled 0, ignored 4, pending 0
```