### PR TITLE
PHOENIX-6922 Javadoc failure while building connectors with Java 11

### DIFF
--- a/phoenix-spark-base/pom.xml
+++ b/phoenix-spark-base/pom.xml
@@ -605,6 +605,13 @@
           </configuration>
         </plugin>
         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <configuration>
+                <skip>${skip.spark.javadoc}</skip>
+            </configuration>
+        </plugin>
+        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
           <executions>

--- a/phoenix5-spark3/pom.xml
+++ b/phoenix5-spark3/pom.xml
@@ -183,6 +183,13 @@
             </ignoredDependencies>
           </configuration>
         </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <configuration>
+                <skip>${skip.spark.javadoc}</skip>
+            </configuration>
+        </plugin>
     </plugins>
   </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,7 @@
     <phoenix.main.version>4</phoenix.main.version>
 
     <skip-scala-tests>true</skip-scala-tests>
+    <skip.spark.javadoc>false</skip.spark.javadoc>
   </properties>
 
   <build>
@@ -926,6 +927,16 @@
       <properties>
         <javadoc.opts>-Xdoclint:none</javadoc.opts>
       </properties>
+    </profile>
+    <!-- Skip Javadoc for 1.8+ See PHOENIX-6922 -->
+    <profile>
+        <id>disable-javadoc-for-spark</id>
+        <activation>
+            <jdk>(8,)</jdk>
+        </activation>
+        <properties>
+            <skip.spark.javadoc>true</skip.spark.javadoc>
+        </properties>
     </profile>
     <!-- this profile should be activated for release builds -->
     <profile>


### PR DESCRIPTION
skip Javadoc generation for Spark connector on JDK 9+