### PR TITLE
Update github action build image to ubuntu-lastest

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,8 +21,7 @@ on:
 
 jobs:
   build:
-    # upgrade to ubuntu-latest after removing Phoenix 4 support
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-lastest
     steps:
     - uses: actions/checkout@v1
     - name: Set up JDK 1.8


### PR DESCRIPTION
Github action fails with error "Detected Maven Version: 3.3.9 is not in the allowed range [3.6.3,).".
Updating build image to `ubuntu-latest` fixes the error and check process is terminating corrrectly.
I don't know if it require a jira number since it is only about running github action on the project.
If it is the case let me know I will create one and link it to this PR.