### PR TITLE
PHOENIX-7488. Use central repo, not repository.apache.org

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,13 +44,6 @@
     <url>http://www.apache.org</url>
   </organization>
 
-  <repositories>
-    <repository>
-      <id>apache release</id>
-      <url>https://repository.apache.org/content/repositories/releases/</url>
-    </repository>
-  </repositories>
-
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

[Build](https://github.com/apache/phoenix-connectors/actions/runs/11933840635/job/33461210942#step:4:1507) tries to download non-Apache artifacts from `apache release` repo:

```
[INFO] Downloading from apache release: https://repository.apache.org/content/repositories/releases/com/google/guava/guava/27.0-jre/guava-27.0-jre.pom
[INFO] Downloading from central: https://repo.maven.apache.org/maven2/com/google/guava/guava/27.0-jre/guava-27.0-jre.pom
[INFO] Downloaded from central: https://repo.maven.apache.org/maven2/com/google/guava/guava/27.0-jre/guava-27.0-jre.pom (8.1 kB at 812 kB/s)
```

This change removes `repository.apache.org` definition, to let the build use `central` repo from super POM.

Please see last item about `repository.apache.org` at https://infra.apache.org/infra-ban.html

https://issues.apache.org/jira/browse/PHOENIX-7488

## How was this patch tested?

Local build (with some retries while I found out correct Java version and how to skip Scala tests):

```
$ mvn -DskipTests -Dskip.scalatest clean package
...
[INFO] Reactor Summary for Apache Phoenix Connectors 6.0.0-SNAPSHOT:
[INFO] 
[INFO] Apache Phoenix Connectors .......................... SUCCESS [  1.639 s]
[INFO] Phoenix Hive 3 Connector for Phoenix 5 ............. SUCCESS [  4.806 s]
[INFO] Shaded Phoenix Hive 3 Connector for Phoenix 5 ...... SUCCESS [02:15 min]
[INFO] Phoenix Hive 4 Connector for Phoenix 5 ............. SUCCESS [  3.213 s]
[INFO] Shaded Phoenix Hive 4 Connector for Phoenix 5 ...... SUCCESS [02:15 min]
[INFO] Phoenix Spark 2 Connector for Phoenix 5 ............ SUCCESS [ 16.846 s]
[INFO] Shaded Phoenix Spark 2 Connector for Phoenix 5 ..... SUCCESS [02:11 min]
[INFO] Phoenix Spark 3 Connector for Phoenix 5 ............ SUCCESS [ 55.221 s]
[INFO] Shaded Phoenix Spark 3 Connector for Phoenix 5 ..... SUCCESS [02:15 min]
[INFO] Phoenix 5 Connectors Distribution Assembly ......... SUCCESS [  7.039 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
```